### PR TITLE
Add usermodules needed for stable communication with router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ USEMODULE += shell_commands
 # additional modules for debugging:
 USEMODULE += ps
 
+USEMODULE += netstats_l2
 
 CFLAGS += -DGNRC_IPV6_NIB_CONF_SLAAC=1
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ USEMODULE += gnrc_ipv6_default
 USEMODULE += gcoap
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
+USEMODULE += gnrc_icmpv6_error
 
 # Specify the mandatory networking modules for IPv6 routing
 USEMODULE += gnrc_ipv6_router_default

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ USEMODULE += gcoap
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 
+# Specify the mandatory networking modules for IPv6 routing
+USEMODULE += gnrc_ipv6_router_default
+
 # Required by gcoap example
 USEMODULE += od
 USEMODULE += fmt
@@ -31,6 +34,10 @@ USEMODULE += shell
 USEMODULE += shell_commands
 # additional modules for debugging:
 USEMODULE += ps
+
+
+CFLAGS += -DGNRC_IPV6_NIB_CONF_SLAAC=1
+
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the


### PR DESCRIPTION
Summary
========
*   Added `GNRC_IPV6_NIB_CONF_SLAAC=1` compile flag to `Makefile`, in order to prevent the
    assigned global IPv6 address to be tentative (`TNT`)
*   Added following usermodules to `Makefile`:
    *   `netstats_l2`
    *   `gnrc_icmpv6_error` (Might actually not be needed)
    *   `gnrc_ipv6_router_default`

    These modules are needed, so that the board is reachable from another device (e.g. Router)