### PR TITLE
Respond with phydat as CBOR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ USEMODULE += ps
 
 USEMODULE += netstats_l2
 
+# Include tinycbor for data representation
+USEPKG += tinycbor
+INCLUDE += $(RIOTPKG)/tinycbor/cbor.h
+
 CFLAGS += -DGNRC_IPV6_NIB_CONF_SLAAC=1
 
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ The idea of these resources is, to offer similar functionality as the
 - `/saul/dev` (POST) needs an ID as argument. Returns some information
   about the sensor for that ID (name and type). 
 
-## Phydat as CBOR
+## Phydat in Concise Binary Object Representation (CBOR)
 
 In all resources by sensor type, we return the [`phydat_t` struct][]
-as [CBOR][]. [CBOR example][] of an temperature sensor:
+in the [CBOR][] data format. In the following code block, you can see
+a [CBOR example][] of what could be returned for a temperature sensor:
 
 ```
 A3                 # map(3)
@@ -59,7 +60,8 @@ A3                 # map(3)
    21              # negative(1)
 ```
 
-This translates to the following JSON:
+If you want to use this resource, you can parse it to JSON. The
+example above translates to the following JSON object:
 
 ``` json
 {"values": [2393], "unit": 2, "scale": -2}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ The idea of these resources is, to offer similar functionality as the
 - `/saul/dev` (POST) needs an ID as argument. Returns some information
   about the sensor for that ID (name and type). 
 
+## Phydat as CBOR
+
+In all resources by sensor type, we return the `phydat_t` as
+[CBOR][].
+
+[CBOR Example][]:
+
+```
+A3                 # map(3)
+   66              # text(6)
+      76616C756573 # "values"
+   81              # array(1)
+      19 0959      # unsigned(2393)
+   64              # text(4)
+      756E6974     # "unit"
+   02              # unsigned(2)
+   65              # text(5)
+      7363616C65   # "scale"
+   21              # negative(1)
+```
+
+This translates to the following JSON:
+
+    {"values": [2393], "unit": 2, "scale": -2}
+
+[cbor]: http://cbor.io/
+
+[cbor example]: http://cbor.me/?bytes=A3(66(76616C756573)-81(19.0959)-64(756E6974)-02-65(7363616C65)-21)
 
 ## Build and Execute
 Enter shell with board command (Phytec)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ sensors of the same type are ignored. More sensor types need to be
 manually added to the code base. These paths can be used without
 knowledge about the RIOT-intern type representation.
 
+Returns `phydat_t` as CBOR; see below for more info.
+
 ### `/sensor`
 The `/sensor` resource is reachable with an `GET` request. As payload
 it needs the ID of a saul sensor type (as they are defined in
@@ -23,6 +25,8 @@ it needs the ID of a saul sensor type (as they are defined in
 out of the box. However, the systems calling this resource, need
 information about the RIOT-intern saul type IDs. This could be used by
 other RIOT powered boards.
+
+Returns `phydat_t` as CBOR; see below for more info.
 
 [saul.h]: https://github.com/RIOT-OS/RIOT/blob/d42c032998e77e122380b3d270ceedb7fff48cda/drivers/include/saul.h#L74
 
@@ -38,10 +42,8 @@ The idea of these resources is, to offer similar functionality as the
 
 ## Phydat as CBOR
 
-In all resources by sensor type, we return the `phydat_t` as
-[CBOR][].
-
-[CBOR Example][]:
+In all resources by sensor type, we return the [`phydat_t` struct][]
+as [CBOR][]. [CBOR example][] of an temperature sensor:
 
 ```
 A3                 # map(3)
@@ -59,11 +61,21 @@ A3                 # map(3)
 
 This translates to the following JSON:
 
-    {"values": [2393], "unit": 2, "scale": -2}
+``` json
+{"values": [2393], "unit": 2, "scale": -2}
+```
+
+Please see the [list of CBOR implementations][] if you want to use
+this resource. The documentation of the [`phydat_t` struct][]
+explains, how these values have to be interpreted.
+
+[`phydat_t` struct]: https://riot-os.org/api/structphydat__t.html
 
 [cbor]: http://cbor.io/
 
 [cbor example]: http://cbor.me/?bytes=A3(66(76616C756573)-81(19.0959)-64(756E6974)-02-65(7363616C65)-21)
+
+[list of cbor implementations]: http://cbor.io/impls.html
 
 ## Build and Execute
 Enter shell with board command (Phytec)

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -278,7 +278,7 @@ CborError export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t 
 
     err = cbor_encoder_close_container(encoder, &mapEncoder);
     if (err != CborNoError) {
-	return err;
+        return err;
     }
 
     return CborNoError;

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -56,6 +56,8 @@ static gcoap_listener_t _listener = {
     NULL
 };
 
+static uint8_t cbor_buf[64] = { 0 };
+
 static ssize_t _saul_dev_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx)
 {
     int pos = 0;
@@ -221,8 +223,6 @@ void export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_l
 
     cbor_encoder_close_container(encoder, &mapEncoder);
 }
-
-static uint8_t cbor_buf[128] = { 0 };
 
 static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx)
 {

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -169,71 +169,53 @@ void export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_l
 
     cbor_encoder_init(encoder, cbor_buf, buf_len, 0);
     if (err != CborNoError) {
-        printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
     }
 
     err = cbor_encoder_create_map(encoder, &mapEncoder, 3);
     if (err != CborNoError) {
-        printf("CborError occured: %d\n", err);
-        printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
     }
-
-    printf("CborError occured: %d: %s (%d); %d\n", err, cbor_error_string(err), cbor_encoder_get_buffer_size(encoder, cbor_buf), __LINE__);
-    printf("No CborError occured, len: %d; %d\n", cbor_encoder_get_buffer_size(&mapEncoder, cbor_buf), __LINE__);
 
     err = cbor_encode_text_stringz(&mapEncoder, "va");
     if (err != CborNoError) {
-        printf("CborError occured: %x: %s (%d); %d\n", err, cbor_error_string(err), cbor_encoder_get_extra_bytes_needed(&mapEncoder), __LINE__);
         return;
     }
 
-    printf("No CborError occured, len: %d; %d\n", cbor_encoder_get_buffer_size(encoder, cbor_buf), __LINE__);
-    printf("No CborError occured, len: %d; %d\n", cbor_encoder_get_buffer_size(&mapEncoder, cbor_buf), __LINE__);
-
     err = cbor_encoder_create_array(&mapEncoder, &aryEncoder, dim);
     if (err != CborNoError) {
-        printf("CborError occured: %x: %s (%d); %d\n", err, cbor_error_string(err), cbor_encoder_get_extra_bytes_needed(&aryEncoder), __LINE__);
         return;
     }
 
     for (uint8_t i = 0; i < dim; i++) {
         err = cbor_encode_int(&aryEncoder, data.val[i]);
         if (err != CborNoError) {
-            printf("CborError occured: %d\n", err);
-            printf("CborError occured: %d; %d\n", err, __LINE__);
             return;
         }
     }
 
     err = cbor_encoder_close_container(&mapEncoder, &aryEncoder);
     if (err != CborNoError) {
-        printf("CborError occured: %d\n", err); printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
     }
 
-    err= cbor_encode_text_stringz(&mapEncoder, "unit");
+    err = cbor_encode_text_stringz(&mapEncoder, "unit");
     if (err != CborNoError) {
-        printf("CborError occured: %d\n", err); printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
     }
 
-    err =cbor_encode_int(&mapEncoder, data.unit);
+    err = cbor_encode_int(&mapEncoder, data.unit);
     if (err != CborNoError) {
-        printf("CborError occured: %d\n", err); printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
     }
 
-    err=cbor_encode_text_stringz(&mapEncoder, "scale");
+    err = cbor_encode_text_stringz(&mapEncoder, "scale");
     if (err != CborNoError) {
-        printf("CborError occured: %d\n", err); printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
     }
 
-    err=cbor_encode_int(&mapEncoder, data.scale);
+    err = cbor_encode_int(&mapEncoder, data.scale);
     if (err != CborNoError) {
-        printf("CborError occured: %d\n", err); printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
     }
 
@@ -283,10 +265,6 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
     export_phydat_to_cbor(&encoder, cbor_buf, sizeof(cbor_buf), res, dim);
 
     size_t buf_size=cbor_encoder_get_buffer_size(&encoder, cbor_buf);
-    for(uint8_t i =0;i<buf_size;i++) {
-        printf("%xx ", cbor_buf[i]);
-    }
-    printf("\n%d\n", cbor_encoder_get_buffer_size(&encoder, cbor_buf));
     if (pdu->payload_len >= cbor_encoder_get_buffer_size(&encoder, cbor_buf)) {
         memcpy(pdu->payload, cbor_buf, cbor_encoder_get_buffer_size(&encoder, cbor_buf));
         resp_len += gcoap_response(pdu, buf, len, COAP_CODE_VALID);
@@ -296,9 +274,6 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
 
     memset(cbor_buf, 0, sizeof(cbor_buf));
     return resp_len;
-    /* write the response buffer with the request device value */
-    /* resp_len += fmt_u16_dec((char *)pdu->payload, res.val[0]);
-       return resp_len; */
 }
 
 void saul_coap_init(void)

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -173,7 +173,7 @@ void export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_l
         return;
     }
 
-    err = cbor_encoder_create_map(encoder, &mapEncoder, 1);
+    err = cbor_encoder_create_map(encoder, &mapEncoder, 3);
     if (err != CborNoError) {
         printf("CborError occured: %d\n", err);
         printf("CborError occured: %d; %d\n", err, __LINE__);

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -284,7 +284,7 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
 
     size_t buf_size=cbor_encoder_get_buffer_size(&encoder, cbor_buf);
     for(uint8_t i =0;i<buf_size;i++) {
-        printf("%x ", cbor_buf[i]);
+        printf("%xx ", cbor_buf[i]);
     }
     printf("\n%d\n", cbor_encoder_get_buffer_size(&encoder, cbor_buf));
     if (pdu->payload_len >= cbor_encoder_get_buffer_size(&encoder, cbor_buf)) {

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -164,66 +164,69 @@ static ssize_t _saul_sensortype_handler(coap_pkt_t* pdu, uint8_t *buf, size_t le
     return _saul_type_handler(pdu, buf, len, &type);
 }
 
-size_t export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_len, phydat_t data, int dim)
+CborError export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_len, phydat_t data, int dim)
 {
     CborEncoder mapEncoder, aryEncoder;
     CborError err = CborNoError;
 
     cbor_encoder_init(encoder, cbor_buf, buf_len, 0);
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     err = cbor_encoder_create_map(encoder, &mapEncoder, 3);
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     err = cbor_encode_text_stringz(&mapEncoder, "va");
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     err = cbor_encoder_create_array(&mapEncoder, &aryEncoder, dim);
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     for (uint8_t i = 0; i < dim; i++) {
         err = cbor_encode_int(&aryEncoder, data.val[i]);
         if (err != CborNoError) {
-            return -1;
+            return err;
         }
     }
 
     err = cbor_encoder_close_container(&mapEncoder, &aryEncoder);
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     err = cbor_encode_text_stringz(&mapEncoder, "unit");
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     err = cbor_encode_int(&mapEncoder, data.unit);
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     err = cbor_encode_text_stringz(&mapEncoder, "scale");
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
     err = cbor_encode_int(&mapEncoder, data.scale);
     if (err != CborNoError) {
-        return -1;
+        return err;
     }
 
-    cbor_encoder_close_container(encoder, &mapEncoder);
+    err = cbor_encoder_close_container(encoder, &mapEncoder);
+    if (err != CborNoError) {
+	return err;
+    }
 
-    return cbor_encoder_get_buffer_size(encoder, cbor_buf);
+    return CborNoError;
 }
 
 static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx)
@@ -264,9 +267,11 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
         }
     }
 
-    size_t buf_size = export_phydat_to_cbor(&encoder, cbor_buf, sizeof(cbor_buf), res, dim);
+    CborError cbor_err = export_phydat_to_cbor(&encoder, cbor_buf, sizeof(cbor_buf), res, dim);
 
-    if (buf_size > 0 && pdu->payload_len >= buf_size) {
+    size_t buf_size = cbor_encoder_get_buffer_size(&encoder, cbor_buf);
+
+    if (cbor_err == CborNoError && buf_size > 0 && pdu->payload_len >= buf_size) {
         memcpy(pdu->payload, cbor_buf, buf_size);
         resp_len += gcoap_response(pdu, buf, len, COAP_CODE_VALID);
     } else {

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -162,12 +162,12 @@ static ssize_t _saul_sensortype_handler(coap_pkt_t* pdu, uint8_t *buf, size_t le
     return _saul_type_handler(pdu, buf, len, &type);
 }
 
-void export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, phydat_t data, int dim)
+void export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_len, phydat_t data, int dim)
 {
     CborEncoder mapEncoder, aryEncoder;
     CborError err = CborNoError;
 
-    cbor_encoder_init(encoder, cbor_buf, sizeof(cbor_buf), 0);
+    cbor_encoder_init(encoder, cbor_buf, buf_len, 0);
     if (err != CborNoError) {
         printf("CborError occured: %d; %d\n", err, __LINE__);
         return;
@@ -280,7 +280,7 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
         }
     }
 
-    export_phydat_to_cbor(&encoder, cbor_buf, res, dim);
+    export_phydat_to_cbor(&encoder, cbor_buf, sizeof(cbor_buf), res, dim);
 
     size_t buf_size=cbor_encoder_get_buffer_size(&encoder, cbor_buf);
     for(uint8_t i =0;i<buf_size;i++) {

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -210,7 +210,7 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
 
     if (cbor_err == CborNoError && buf_size > 0 && pdu->payload_len >= buf_size) {
         memcpy(pdu->payload, cbor_buf, buf_size);
-        resp_len += gcoap_response(pdu, buf, len, COAP_CODE_VALID);
+        resp_len += buf_size;
     } else {
         resp_len = gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
     }

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -234,7 +234,7 @@ CborError export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t 
         return err;
     }
 
-    err = cbor_encode_text_stringz(&mapEncoder, "va");
+    err = cbor_encode_text_stringz(&mapEncoder, "values");
     if (err != CborNoError) {
         return err;
     }


### PR DESCRIPTION
This pull request changes the `_sense_type_handler` to respond with CBOR instead of text. Affects all resources by that handler (`/sensor`, `/temp`, `/hum` …). The data format is documented in `README.md` (and the presentation for milestone 3 in #20). in the response are also all available values of a single device, thus resolving part of #8. @EM000 might be interested in this change, because the web app needs to handle the response differently.

Closes #12