### PR TITLE
Include multiple devices in CBOR response

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,38 +44,34 @@ The idea of these resources is, to offer similar functionality as the
 
 In all resources by sensor type, we return the [`phydat_t` struct][]
 in the [CBOR][] data format. In the following code block, you can see
-a [CBOR example][] of what could be returned for a temperature sensor:
-
-```
-A3                 # map(3)
-   66              # text(6)
-      76616C756573 # "values"
-   81              # array(1)
-      19 0959      # unsigned(2393)
-   64              # text(4)
-      756E6974     # "unit"
-   02              # unsigned(2)
-   65              # text(5)
-      7363616C65   # "scale"
-   21              # negative(1)
-```
-
-If you want to use this resource, you can parse it to JSON. The
-example above translates to the following JSON object:
+the parsed JSON for a [CBOR example][] that could be returned for a
+temperature request with two sensors:
 
 ``` json
-{"values": [2393], "unit": 2, "scale": -2}
+[
+    {
+        "values": [2398],
+        "unit": 2,
+        "scale": -2
+    },
+    {
+        "values": [226],
+        "unit": 2,
+        "scale": -1
+    }
+]
 ```
 
-Please see the [list of CBOR implementations][] if you want to use
-this resource. The documentation of the [`phydat_t` struct][]
-explains, how these values have to be interpreted.
+If you want to use this resource, you can parse it to JSON. Please see
+the [list of CBOR implementations][]. The documentation of the
+[`phydat_t` struct][] explains, how these values have to be
+interpreted.
 
 [`phydat_t` struct]: https://riot-os.org/api/structphydat__t.html
 
 [cbor]: http://cbor.io/
 
-[cbor example]: http://cbor.me/?bytes=A3(66(76616C756573)-81(19.0959)-64(756E6974)-02-65(7363616C65)-21)
+[cbor example]: http://cbor.me/?bytes=9F(A3(66(76616C756573)-81(19.095E)-64(756E6974)-02-65(7363616C65)-21)-A3(66(76616C756573)-81(18.E2)-64(756E6974)-02-65(7363616C65)-20)-FF)
 
 [list of cbor implementations]: http://cbor.io/impls.html
 

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -31,7 +31,7 @@ static ssize_t _saul_dev_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void
 static ssize_t _saul_sensortype_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
-CborError export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_len, phydat_t data, int dim);
+CborError export_phydat_to_cbor(CborEncoder *encoder, phydat_t data, int dim);
 
 /* supported sense types, used for context pointer in coap_resource_t */
 uint8_t class_servo = SAUL_ACT_SERVO;
@@ -172,8 +172,9 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
     saul_reg_t *dev = saul_reg_find_type(type);
     phydat_t res;
     int dim;
-    size_t resp_len;
-    CborEncoder encoder;
+    size_t resp_len, buf_size;
+    CborEncoder encoder, aryEncoder;
+    CborError cbor_err = CborNoError;
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
     coap_opt_add_format(pdu, COAP_FORMAT_CBOR);
@@ -191,22 +192,25 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
         }
     }
 
-    dim = saul_reg_read(dev, &res);
-    if (dim <= 0) {
-        char *err = "no values found";
-        if (pdu->payload_len >= strlen(err)) {
-            memcpy(pdu->payload, err, strlen(err));
-            resp_len += gcoap_response(pdu, buf, len, COAP_CODE_404);
-            return resp_len;
-        }
-        else {
-            return gcoap_response(pdu, buf, len, COAP_CODE_404);
-        }
+    cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
+
+    cbor_err = cbor_encoder_create_array(&encoder, &aryEncoder, CborIndefiniteLength);
+    if (cbor_err != CborNoError) {
+        return gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
     }
 
-    CborError cbor_err = export_phydat_to_cbor(&encoder, cbor_buf, sizeof(cbor_buf), res, dim);
+    while (dev != NULL && cbor_err == CborNoError) {
+        dim = saul_reg_read(dev, &res);
 
-    size_t buf_size = cbor_encoder_get_buffer_size(&encoder, cbor_buf);
+        if (dim > 0) {
+            cbor_err = export_phydat_to_cbor(&aryEncoder, res, dim);
+            buf_size = cbor_encoder_get_buffer_size(&encoder, cbor_buf);
+        }
+
+        dev = dev->next;
+    }
+
+    cbor_err = cbor_encoder_close_container(&encoder, &aryEncoder);
 
     if (cbor_err == CborNoError && buf_size > 0 && pdu->payload_len >= buf_size) {
         memcpy(pdu->payload, cbor_buf, buf_size);
@@ -219,15 +223,10 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
     return resp_len;
 }
 
-CborError export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t buf_len, phydat_t data, int dim)
+CborError export_phydat_to_cbor(CborEncoder *encoder, phydat_t data, int dim)
 {
     CborEncoder mapEncoder, aryEncoder;
     CborError err = CborNoError;
-
-    cbor_encoder_init(encoder, cbor_buf, buf_len, 0);
-    if (err != CborNoError) {
-        return err;
-    }
 
     err = cbor_encoder_create_map(encoder, &mapEncoder, 3);
     if (err != CborNoError) {
@@ -278,7 +277,7 @@ CborError export_phydat_to_cbor(CborEncoder *encoder, uint8_t *cbor_buf, size_t 
 
     err = cbor_encoder_close_container(encoder, &mapEncoder);
     if (err != CborNoError) {
-	return err;
+        return err;
     }
 
     return CborNoError;

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -197,6 +197,7 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
 
     cbor_err = cbor_encoder_create_array(&encoder, &aryEncoder, CborIndefiniteLength);
     if (cbor_err != CborNoError) {
+	puts("Couldn’t create an cbor array");
         return gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
     }
 
@@ -217,6 +218,10 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
         memcpy(pdu->payload, cbor_buf, buf_size);
         resp_len += buf_size;
     } else {
+	puts("Could not reply with the cbor data.");
+	if (cbor_err != CborNoError) puts("CborError occured");
+	if (buf_size <= 0) puts("Buffer size is <= 0");
+	if (pdu->payload_len < buf_size) puts("Payload length is to short for buffer");
         resp_len = gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
     }
 

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -206,13 +206,13 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
 
         if (dim > 0) {
             cbor_err = export_phydat_to_cbor(&aryEncoder, res, dim);
-            buf_size = cbor_encoder_get_buffer_size(&encoder, cbor_buf);
         }
 
         dev = dev->next;
     }
 
     cbor_err = cbor_encoder_close_container(&encoder, &aryEncoder);
+    buf_size = cbor_encoder_get_buffer_size(&encoder, cbor_buf);
 
     if (cbor_err == CborNoError && buf_size > 0 && pdu->payload_len >= buf_size) {
         memcpy(pdu->payload, cbor_buf, buf_size);

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -197,7 +197,6 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
 
     cbor_err = cbor_encoder_create_array(&encoder, &aryEncoder, CborIndefiniteLength);
     if (cbor_err != CborNoError) {
-	puts("Couldn’t create an cbor array");
         return gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
     }
 
@@ -218,10 +217,6 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
         memcpy(pdu->payload, cbor_buf, buf_size);
         resp_len += buf_size;
     } else {
-	puts("Could not reply with the cbor data.");
-	if (cbor_err != CborNoError) puts("CborError occured");
-	if (buf_size <= 0) puts("Buffer size is <= 0");
-	if (pdu->payload_len < buf_size) puts("Payload length is to short for buffer");
         resp_len = gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
     }
 

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -201,10 +201,12 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
     }
 
     while (dev != NULL && cbor_err == CborNoError) {
-        dim = saul_reg_read(dev, &res);
+        if (dev->driver->type == type) {
+            dim = saul_reg_read(dev, &res);
 
-        if (dim > 0) {
-            cbor_err = export_phydat_to_cbor(&aryEncoder, res, dim);
+	    if (dim > 0) {
+                cbor_err = export_phydat_to_cbor(&aryEncoder, res, dim);
+            }
         }
 
         dev = dev->next;

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -173,7 +173,7 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
     saul_reg_t *dev = saul_reg_find_type(type);
     phydat_t res;
     int dim;
-    size_t resp_len, buf_size;
+    size_t resp_len, buf_size = 0;
     CborEncoder encoder, aryEncoder;
     CborError cbor_err = CborNoError;
 


### PR DESCRIPTION
Closes #8.

The response is an array that contains the phydat objects (via #19) of all devices of the requested sensor type.

In the issue I wrote that “based on CBOR / tinycbor best practices, I would maybe respond with an CBOR object containing the CBOR array.” But according to the [TinyCBOR encoder documentation](https://intel.github.io/tinycbor/current/a00046.html#details) “the outermost CborEncoder is usually used to encode exactly one item, most often an array or map.”

## how was this tested

This is the saul status on the server node:

```
> saul
2019-12-09 16:28:03,402 # saul
2019-12-09 16:28:03,404 # ID	Class		Name
2019-12-09 16:28:03,406 # #0	ACT_SWITCH	LED(red)
2019-12-09 16:28:03,408 # #1	ACT_SWITCH	LED(green)
2019-12-09 16:28:03,410 # #2	ACT_SWITCH	LED(blue)
2019-12-09 16:28:03,412 # #3	SENSE_BTN	Button(SW0)
2019-12-09 16:28:03,414 # #4	SENSE_BTN	Button(CS0)
2019-12-09 16:28:03,416 # #5	SENSE_TEMP	hdc1000
2019-12-09 16:28:03,419 # #6	SENSE_HUM	hdc1000
2019-12-09 16:28:03,421 # #7	SENSE_MAG	mag3110
2019-12-09 16:28:03,421 # #8	SENSE_ACCEL	mma8x5x
2019-12-09 16:28:03,423 # #9	SENSE_TEMP	mpl3115a2
2019-12-09 16:28:03,425 # #10	SENSE_PRESS	mpl3115a2
2019-12-09 16:28:03,428 # #11	SENSE_COLOR	tcs37727
> 
```

* Send a `GET /temp` request, because there are multiple temperature sensors:
  
  ```
  coap get -c fe80::47f7:6d7c:828f:3332 5683 /temp
  2019-12-09 16:36:10,563 # coap get -c fe80::47f7:6d7c:828f:3332 5683 /temp
  2019-12-09 16:36:10,567 # gcoap_cli: sending msg ID 53885, 11 bytes
  > 2019-12-09 16:36:10,607 #  gcoap: response Success, code 2.05, 51 bytes
  2019-12-09 16:36:10,613 # 00000000  9F  A3  66  76  61  6C  75  65  73  81  19  09  5B  64  75  6E
  2019-12-09 16:36:10,620 # 00000010  69  74  02  65  73  63  61  6C  65  21  A3  66  76  61  6C  75
  2019-12-09 16:36:10,626 # 00000020  65  73  81  18  E4  64  75  6E  69  74  02  65  73  63  61  6C
  2019-12-09 16:36:10,628 # 00000030  65  20  FF
  ```

  Inspect the response in the [CBOR Playground](http://cbor.me/?bytes=9F(A3(66(76616C756573)-81(19.095B)-64(756E6974)-02-65(7363616C65)-21)-A3(66(76616C756573)-81(18.E4)-64(756E6974)-02-65(7363616C65)-20)-FF)).

* Send a `GET /hum` request, because there’s only one humidity sensor:

  ```
  coap get -c fe80::47f7:6d7c:828f:3332 5683 /hum
  2019-12-09 16:37:19,639 # coap get -c fe80::47f7:6d7c:828f:3332 5683 /hum
  2019-12-09 16:37:19,643 # gcoap_cli: sending msg ID 53886, 10 bytes
  > 2019-12-09 16:37:19,682 #  gcoap: response Success, code 2.05, 28 bytes
  2019-12-09 16:37:19,688 # 00000000  9F  A3  66  76  61  6C  75  65  73  81  19  0D  1B  64  75  6E
  2019-12-09 16:37:19,694 # 00000010  69  74  18  1A  65  73  63  61  6C  65  21  FF
  ```

  Inspect the response in the [CBOR Playground](http://cbor.me/?bytes=9F(A3(66(76616C756573)-81(19.0D1B)-64(756E6974)-18.1A-65(7363616C65)-21)-FF)).