### PR TITLE
Feature/rd registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ USEMODULE += ps
 USEMODULE += netstats_l2
 CFLAGS += -DGNRC_IPV6_NIB_CONF_SLAAC=1
 
+# For debugging and demonstration purposes the lifetime is limited to 60s
+CFLAGS += -DCORD_LT=5
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/Makefile
+++ b/Makefile
@@ -30,20 +30,21 @@ USEMODULE += fmt
 
 # we want to use SAUL:
 USEMODULE += saul_default
-# include RIOT's resource directory endpoint
-USEMODULE += cord_ep_standalone
 # include the shell:
 USEMODULE += shell
 USEMODULE += shell_commands
 # additional modules for debugging:
 USEMODULE += ps
 
+# Module for registering to Resource Directory (RD) 
+USEMODULE += cord_ep
+
 # needed so that the board can be reached
 USEMODULE += netstats_l2
 CFLAGS += -DGNRC_IPV6_NIB_CONF_SLAAC=1
 
-# For debugging and demonstration purposes the lifetime is limited to 60s
-CFLAGS += -DCORD_LT=5
+# For debugging and demonstration purposes the lifetime is limited to 30s
+CFLAGS += -DCORD_LT=30
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
@@ -54,3 +55,4 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,16 @@ USEMODULE += fmt
 
 # we want to use SAUL:
 USEMODULE += saul_default
+# include RIOT's resource directory endpoint
+USEMODULE += cord_ep_standalone
 # include the shell:
 USEMODULE += shell
 USEMODULE += shell_commands
 # additional modules for debugging:
 USEMODULE += ps
 
+# needed so that the board can be reached
 USEMODULE += netstats_l2
-
 CFLAGS += -DGNRC_IPV6_NIB_CONF_SLAAC=1
 
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ explains, how these values have to be interpreted.
 
 [list of cbor implementations]: http://cbor.io/impls.html
 
+## Resource Directory (RD)
+A RD is a service that stores information about the COAP-routes of a device, so that a client can search for specific routes
+within a network of devices, instead of querying each device itself (see [RFC CoRE Resource Directory v15](https://tools.ietf.org/html/draft-ietf-core-resource-directory-15)).
+
+Following features are implemented in this project:
+1.  Automatic registration on device startup
+2.  Periodic update of RD entry
+3.  Reregistration when an update fails
+
+The default update time is 30s and should be changed to the wanted time (in seconds) for production, by changing following line in the Makefile: `CFLAGS += -DCORD_LT=30s`.
+
 ## Build and Execute
 Enter shell with board command (Phytec)
 

--- a/main.c
+++ b/main.c
@@ -31,19 +31,17 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 extern void saul_coap_init(void);
 
 /* we will use custom event handler for dumping cord_ep events */
-static void _on_ep_event(cord_ep_standalone_event_t event)
+static void _on_ep_event(saul_cord_ep_event_t event)
 {
     switch (event) {
-        case CORD_EP_REGISTERED:
-            puts("DEBUG: RD endpoint event: now registered with a RD");
+        case SAUL_CORD_EP_REGISTERED:
+            puts("DEBUG: Registered successfully with RD");
             break;
-        case CORD_EP_DEREGISTERED:
-            puts("DEBUG: RD endpoint event: dropped client registration");
-            puts("DEBUG: You should try to register again:)");
-            //saul_cord_ep_register(CORD_EP_ADDRESS);
+        case SAUL_CORD_EP_DEREGISTERED:
+            puts("DEBUG: Deregistered from RD");
             break;
-        case CORD_EP_UPDATED:
-            puts("DEBUG: RD endpoint event: successfully updated client registration");
+        case SAUL_CORD_EP_UPDATED:
+            puts("DEBUG: Updated successfully the client registration");
             break;
     }
 }
@@ -58,7 +56,8 @@ int main(void)
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
     saul_cord_ep_register_cb(_on_ep_event);
-    saul_cord_ep_register(CORD_EP_ADDRESS); 
+    saul_cord_ep_create(CORD_EP_ADDRESS);
+    saul_cord_ep_run(); 
    
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/main.c
+++ b/main.c
@@ -21,12 +21,72 @@
 #include <stdio.h>
 #include "msg.h"
 #include "shell.h"
+#include "net/cord/config.h"
+#include "net/cord/ep.h"
+#include "net/nanocoap.h"
+#include "net/sock/util.h"
+#include "net/cord/ep_standalone.h"
 
 #define MAIN_QUEUE_SIZE (4)
+#define CORD_EP_ADDRESS "[fdaa:bb:cc:dd::1]:5683"
+
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 extern void saul_coap_init(void);
 
+/* we will use custom event handler for dumping cord_ep events */
+static void _on_ep_event(cord_ep_standalone_event_t event)
+{
+    switch (event) {
+        case CORD_EP_REGISTERED:
+            puts("DEBUG: RD endpoint event: now registered with a RD");
+            break;
+        case CORD_EP_DEREGISTERED:
+            puts("DEBUG: RD endpoint event: dropped client registration");
+            break;
+        case CORD_EP_UPDATED:
+            puts("DEBUG: RD endpoint event: successfully updated client registration");
+            break;
+    }
+}
+
+//static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
+//{
+//    ep->port = 0;
+//    if (sock_udp_str2ep(ep, addr) < 0) {
+//        return -1;
+//    }
+//    ep->family  = AF_INET6;
+//    ep->netif   = SOCK_ADDR_ANY_NETIF;
+//    if (ep->port == 0) {
+//        ep->port = COAP_PORT;
+//    }
+//    return 0;
+//}
+//
+//static int _register(char* address) {
+//    sock_udp_ep_t remote;
+//    char *regif = NULL;
+//
+//    if (make_sock_ep(&remote, address) < 0) {
+//        puts("error: unable to parse address\n");
+//        return 1;
+//    }
+//     
+//    puts("Registering with RD now, this may take a short while...");
+//    
+//    if (cord_ep_register(&remote, regif) != CORD_EP_OK) {
+//        puts("error: registration failed");
+//        return 1; 
+//    }
+//    else {
+//        puts("registration successful\n");
+//        cord_ep_dump_status();
+//    }
+//
+//    return 0;
+//}
+//
 int main(void)
 {
     puts("Welcome to RIOT!\n");
@@ -36,6 +96,15 @@ int main(void)
 
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
+    cord_ep_standalone_reg_cb(_on_ep_event);
+    //cord_ep_standalone_run();
+   
+    printf("DEBUG_RD_ADDRESS: %s", CORD_EP_ADDRESS);
+    
+   // while(_register(CORD_EP_ADDRESS)){
+   //     puts("Try again to register to RD deamon");
+   // }
+   
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 

--- a/main.c
+++ b/main.c
@@ -21,11 +21,7 @@
 #include <stdio.h>
 #include "msg.h"
 #include "shell.h"
-#include "net/cord/config.h"
-#include "net/cord/ep.h"
-#include "net/nanocoap.h"
-#include "net/sock/util.h"
-#include "net/cord/ep_standalone.h"
+#include "saul_cord_ep.h"
 
 #define MAIN_QUEUE_SIZE (4)
 #define CORD_EP_ADDRESS "[fdaa:bb:cc:dd::1]:5683"
@@ -43,6 +39,8 @@ static void _on_ep_event(cord_ep_standalone_event_t event)
             break;
         case CORD_EP_DEREGISTERED:
             puts("DEBUG: RD endpoint event: dropped client registration");
+            puts("DEBUG: You should try to register again:)");
+            //saul_cord_ep_register(CORD_EP_ADDRESS);
             break;
         case CORD_EP_UPDATED:
             puts("DEBUG: RD endpoint event: successfully updated client registration");
@@ -50,43 +48,6 @@ static void _on_ep_event(cord_ep_standalone_event_t event)
     }
 }
 
-//static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
-//{
-//    ep->port = 0;
-//    if (sock_udp_str2ep(ep, addr) < 0) {
-//        return -1;
-//    }
-//    ep->family  = AF_INET6;
-//    ep->netif   = SOCK_ADDR_ANY_NETIF;
-//    if (ep->port == 0) {
-//        ep->port = COAP_PORT;
-//    }
-//    return 0;
-//}
-//
-//static int _register(char* address) {
-//    sock_udp_ep_t remote;
-//    char *regif = NULL;
-//
-//    if (make_sock_ep(&remote, address) < 0) {
-//        puts("error: unable to parse address\n");
-//        return 1;
-//    }
-//     
-//    puts("Registering with RD now, this may take a short while...");
-//    
-//    if (cord_ep_register(&remote, regif) != CORD_EP_OK) {
-//        puts("error: registration failed");
-//        return 1; 
-//    }
-//    else {
-//        puts("registration successful\n");
-//        cord_ep_dump_status();
-//    }
-//
-//    return 0;
-//}
-//
 int main(void)
 {
     puts("Welcome to RIOT!\n");
@@ -96,17 +57,12 @@ int main(void)
 
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
-    cord_ep_standalone_reg_cb(_on_ep_event);
-    //cord_ep_standalone_run();
-   
-    printf("DEBUG_RD_ADDRESS: %s", CORD_EP_ADDRESS);
-    
-   // while(_register(CORD_EP_ADDRESS)){
-   //     puts("Try again to register to RD deamon");
-   // }
+    saul_cord_ep_register_cb(_on_ep_event);
+    saul_cord_ep_register(CORD_EP_ADDRESS); 
    
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }
+

--- a/saul_coap.c
+++ b/saul_coap.c
@@ -24,8 +24,6 @@
 #include "saul_reg.h"
 #include "fmt.h"
 #include "net/gcoap.h"
-#include "net/cord/common.h"
-#include "net/cord/ep_standalone.h"
 
 static ssize_t _saul_cnt_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _saul_dev_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
@@ -50,22 +48,6 @@ static const coap_resource_t _resources[] = {
     { "/temp", COAP_GET, _saul_type_handler, &class_temp },
     { "/voltage", COAP_GET, _saul_type_handler, &class_voltage },
 };
-
-/* we will use a custom event handler for dumping cord_ep events */
-static void _on_ep_event(cord_ep_standalone_event_t event)
-{
-    switch (event) {
-        case CORD_EP_REGISTERED:
-            puts("RD endpoint event: now registered with a RD");
-            break;
-        case CORD_EP_DEREGISTERED:
-            puts("RD endpoint event: dropped client registration");
-            break;
-        case CORD_EP_UPDATED:
-            puts("RD endpoint event: successfully updated client registration");
-            break;
-    }
-}
 
 static gcoap_listener_t _listener = {
     &_resources[0],
@@ -229,6 +211,5 @@ static ssize_t _saul_type_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, voi
 void saul_coap_init(void)
 {
     gcoap_register_listener(&_listener);
-    cord_ep_standalone_reg_cb(_on_ep_event);
 }
 

--- a/saul_cord_ep.c
+++ b/saul_cord_ep.c
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup     pkg
+ * @{
+ *
+ * @file
+ * @brief       Register SAUL registry to resource directory
+ *
+ * @author      Matthias Bräuer <matthias.braeuer@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "saul_cord_ep.h"
+
+/**
+ * Execute the `ifconfig` command.
+ */
+extern int _gnrc_netif_config(int argc, char **argv);
+
+/**
+ * Create an UDP socket.
+ */
+static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
+{
+    ep->port = 0;
+    if (sock_udp_str2ep(ep, addr) < 0) {
+        return -1;
+    }
+    ep->family  = AF_INET6;
+    ep->netif   = SOCK_ADDR_ANY_NETIF;
+    if (ep->port == 0) {
+        ep->port = COAP_PORT;
+    }
+    return 0;
+}
+
+/**
+ * Try to register to resource directory service.
+ *
+ * @param address The IPv6 address of the resource directory service
+ */
+static int register_rd(const char* address) {
+    sock_udp_ep_t remote;
+    char *regif = NULL;
+
+    if (make_sock_ep(&remote, address) < 0) {
+        puts("error: unable to parse address\n");
+        return 1;
+    }
+     
+    puts("Registering with RD now, this may take a short while...");
+    
+    if (cord_ep_register(&remote, regif) != CORD_EP_OK) {
+        puts("error: registration failed");
+        return 1; 
+    }
+    else {
+        puts("registration successful\n");
+        cord_ep_dump_status();
+    }
+
+    return 0;
+}
+
+void saul_cord_ep_register_cb(cord_ep_standalone_cb_t cb) {
+    cord_ep_standalone_reg_cb(cb);
+}
+
+void saul_cord_ep_register(const char* ip_address) {
+    printf("DEBUG_RD_ADDRESS: %s\n", ip_address);
+
+    while(register_rd(ip_address)){
+        _gnrc_netif_config(0, NULL);
+        puts("Try again to register to RD deamon");
+    }
+}
+

--- a/saul_cord_ep.c
+++ b/saul_cord_ep.c
@@ -52,7 +52,7 @@ static void _set_timer(void)
  * @param[in] event The event that occurred
  */
 static void _notify(saul_cord_ep_event_t event) {
-    if(_cb != NULL) {
+    if (_cb != NULL) {
         _cb(event);
     }
 }
@@ -93,13 +93,11 @@ static int register_rd(void) {
     puts("Registering with RD now, this may take a short while...");
     
     if (cord_ep_register(&remote, regif) != CORD_EP_OK) {
-	_notify(SAUL_CORD_EP_REGISTERED);
+	_notify(SAUL_CORD_EP_DEREGISTERED);
         return 1; 
     }
-    else {
-	_notify(SAUL_CORD_EP_DEREGISTERED);
-        cord_ep_dump_status();
-    }
+
+    _notify(SAUL_CORD_EP_REGISTERED);
 
     return 0;
 }
@@ -107,9 +105,11 @@ static int register_rd(void) {
 static void saul_cord_ep_register(void) {
     printf("DEBUG: RD-ADDRESS: %s\n", ip);
 
-    while(register_rd()){
+    while (register_rd()) {
         puts("Try again to register to RD deamon");
     }
+
+    cord_ep_dump_status();
 }
 
 static void *_reg_runner(void *arg)
@@ -129,7 +129,7 @@ static void *_reg_runner(void *arg)
                 _notify(SAUL_CORD_EP_UPDATED);
             }
             else {
-		_notify(SAUL_CORD_EP_DEREGISTERED);
+	        _notify(SAUL_CORD_EP_DEREGISTERED);
 		saul_cord_ep_register();
                 _set_timer(); 
             }

--- a/saul_cord_ep.c
+++ b/saul_cord_ep.c
@@ -93,7 +93,7 @@ static int register_rd(void) {
     puts("Registering with RD now, this may take a short while...");
     
     if (cord_ep_register(&remote, regif) != CORD_EP_OK) {
-	_notify(SAUL_CORD_EP_DEREGISTERED);
+        _notify(SAUL_CORD_EP_DEREGISTERED);
         return 1; 
     }
 
@@ -129,8 +129,8 @@ static void *_reg_runner(void *arg)
                 _notify(SAUL_CORD_EP_UPDATED);
             }
             else {
-	        _notify(SAUL_CORD_EP_DEREGISTERED);
-		saul_cord_ep_register();
+                _notify(SAUL_CORD_EP_DEREGISTERED);
+                saul_cord_ep_register();
                 _set_timer(); 
             }
         }

--- a/saul_cord_ep.h
+++ b/saul_cord_ep.h
@@ -9,7 +9,7 @@
  * @{
  *
  * @file
- * @brief       Register SAUL registry to resource directory
+ * @brief       Register SAUL registry to resource directory and update it periodically.
  *
  * @author      Matthias Bräuer <matthias.braeuer@haw-hamburg.de>
  *
@@ -20,22 +20,53 @@
 #include "net/cord/config.h"
 #include "net/cord/ep.h"
 #include "net/sock/util.h"
-#include "net/cord/ep_standalone.h"
 
 /**
- * Register saul registry to a resource directory service.
- *
- * @param ip_address The IPv6 address of the resource directory service
+ * @brief Possible types of events when interacting with a Resource Directory. 
  */
-void saul_cord_ep_register(const char *ip_address);
+typedef enum {
+   SAUL_CORD_EP_REGISTERED,
+   SAUL_CORD_EP_DEREGISTERED,
+   SAUL_CORD_EP_UPDATED,
+} saul_cord_ep_event_t;
 
 /**
- * Register a callback to resource directory functions.
+ * @brief Callback function signature for RD endpoint state synchronization.
  *
- * This callback is called when an answer from the resource
- * directory is received.
+ * The registered callback function is executed in the context of the dedicated
+ * RD endpoint's thread.
  *
- * @param cb The callback to be called
+ * @param[in] event Type of event
  */
-void saul_cord_ep_register_cb(cord_ep_standalone_cb_t cb);
+typedef void (*saul_cord_ep_cb_t)(saul_cord_ep_event_t event);
+
+/**
+ * @brief Create the saul-cord thread.
+ *
+ * @param[in] ip_address The IPv6 address of the resource directory service
+ *
+ * @warning This function must only be called once (typically during system
+ *          initialization)
+ */
+void saul_cord_ep_create(const char *ip_address);
+
+/**
+ * @brief Run the saul-cord thread. 
+ *
+ * @warning This function must only be called once (typically during system
+ *          initialization)
+ */
+void saul_cord_ep_run(void);
+
+/**
+ * @brief Register a callback to be notified about RD endpoint state changes.
+ *
+ * Only a single callback can be active at any point in time, so setting a new
+ * callback will override the existing one.
+ *
+ * @pre @p cb != NULL
+ *
+ * @param[in] cb The callback to be executed on RD endpoint state changes 
+ */
+void saul_cord_ep_register_cb(saul_cord_ep_cb_t cb);
 

--- a/saul_cord_ep.h
+++ b/saul_cord_ep.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup     pkg
+ * @{
+ *
+ * @file
+ * @brief       Register SAUL registry to resource directory
+ *
+ * @author      Matthias Bräuer <matthias.braeuer@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "net/nanocoap.h"
+#include "net/cord/config.h"
+#include "net/cord/ep.h"
+#include "net/sock/util.h"
+#include "net/cord/ep_standalone.h"
+
+/**
+ * Register saul registry to a resource directory service.
+ *
+ * @param ip_address The IPv6 address of the resource directory service
+ */
+void saul_cord_ep_register(const char *ip_address);
+
+/**
+ * Register a callback to resource directory functions.
+ *
+ * This callback is called when an answer from the resource
+ * directory is received.
+ *
+ * @param cb The callback to be called
+ */
+void saul_cord_ep_register_cb(cord_ep_standalone_cb_t cb);
+

--- a/saul_cord_ep.h
+++ b/saul_cord_ep.h
@@ -15,11 +15,17 @@
  *
  * @}
  */
+#ifndef SAUL_CORD_EP_H
+#define SAUL_CORD_EP_H
 
 #include "net/nanocoap.h"
 #include "net/cord/config.h"
 #include "net/cord/ep.h"
 #include "net/sock/util.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /**
  * @brief Possible types of events when interacting with a Resource Directory. 
@@ -69,4 +75,11 @@ void saul_cord_ep_run(void);
  * @param[in] cb The callback to be executed on RD endpoint state changes 
  */
 void saul_cord_ep_register_cb(saul_cord_ep_cb_t cb);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SAUL_CORD_EP_H */
 


### PR DESCRIPTION
- Register automatically to a Resource Directory
- Send an update periodically if device is registered
- Reregister to Resource Directory if update failed for any reason

**Note**: It may be necessary to wait a certain time on startup until the board is fully configured (has non-tentative IPv6 address, ...), or better trigger registration as soon as the configuration is done (if it is somehow possible).

For more information check out issue #14.

Closes #14